### PR TITLE
feat: add combined breakpoint demo with styling and logic

### DIFF
--- a/angular-sandbox/README.md
+++ b/angular-sandbox/README.md
@@ -57,3 +57,122 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Container Query Directive
+
+This project includes a standalone directive for programmatic container-query behavior:
+
+- Selector: `[appCq]`
+- Export: `#ref="cq"`
+- File: `src/app/directives/container-query.directive.ts`
+
+### Features
+
+- Observes host or parent container dimensions with `ResizeObserver`
+- Supports breakpoints from array or object map
+- Supports width-only, height-only, or both-axis matching
+- Applies active-breakpoint class with customizable prefix
+- Optional CSS custom properties output with customizable prefix
+- Signal API + RxJS observable API
+- Manual recalculation via exported directive instance
+- Zone-less friendly: observer work runs outside Angular zone
+
+### API
+
+Inputs:
+
+- `[appCq]`: `CqBreakpointsInput` (required)
+- `[cqComparisonStrategy]`: `'width' | 'height' | 'both'` (default: `'width'`)
+- `[cqDefaultBreakpoint]`: `string | null` fallback breakpoint name when no match
+- `[cqEmitOnBreakpointChangeOnly]`: `boolean` (default: `false`)
+- `[cqObserveParent]`: `boolean` (default: `false`)
+- `[cqClassPrefix]`: `string` (default: `'cq'`)
+- `[cqCssVariables]`: `boolean` (default: `false`)
+- `[cqCssVarPrefix]`: `string` (default: `'cq'`)
+
+Exported API (`#cq="cq"`):
+
+- `cq.state()`: signal value with breakpoint + dimensions
+- `cq.state$`: observable stream of state
+- `cq.breakpoint()`: active breakpoint name
+- `cq.dimensions()`: current dimensions
+- `cq.recalculate()`: manual recalculation
+
+Types:
+
+```ts
+type CqComparisonStrategy = 'width' | 'height' | 'both';
+
+interface CqBreakpointRange {
+	minWidth?: number;
+	maxWidth?: number;
+	minHeight?: number;
+	maxHeight?: number;
+}
+
+interface CqNamedBreakpoint extends CqBreakpointRange {
+	name: string;
+}
+
+type CqBreakpointMap = Record<string, CqBreakpointRange>;
+type CqBreakpointsInput = CqNamedBreakpoint[] | CqBreakpointMap;
+```
+
+### Examples
+
+Basic usage:
+
+```html
+<div [appCq]="{ compact: { maxWidth: 479 }, wide: { minWidth: 480 } }" #cq="cq">
+	Active: {{ cq.breakpoint() }}
+</div>
+```
+
+Multiple breakpoints:
+
+```html
+<div
+	[appCq]="[
+		{ name: 'xs', maxWidth: 299 },
+		{ name: 'sm', minWidth: 300, maxWidth: 499 },
+		{ name: 'lg', minWidth: 500 }
+	]"
+	#cq="cq"
+>
+	{{ cq.state().activeClass }}
+</div>
+```
+
+Using signals:
+
+```html
+<div [appCq]="breakpoints" #cq="cq">{{ cq.dimensions().width }} x {{ cq.dimensions().height }}</div>
+```
+
+Using observable:
+
+```html
+<div [appCq]="breakpoints" [cqEmitOnBreakpointChangeOnly]="true" #cq="cq"></div>
+<p>{{ (cq.state$ | async)?.breakpoint ?? 'none' }}</p>
+```
+
+Using CSS variables:
+
+```html
+<div
+	[appCq]="breakpoints"
+	[cqCssVariables]="true"
+	[cqCssVarPrefix]="'demo-cq'"
+	#cq="cq"
+>
+	{{ cq.breakpoint() }}
+</div>
+```
+
+Class prefix customization:
+
+```html
+<div [appCq]="breakpoints" [cqClassPrefix]="'layout'" #cq="cq">
+	{{ cq.state().activeClass }}
+</div>
+```

--- a/angular-sandbox/package-lock.json
+++ b/angular-sandbox/package-lock.json
@@ -479,7 +479,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.7.tgz",
       "integrity": "sha512-YFdnU5z8JloJjLYa52OyCOULQhqEE/ym7vKfABySWDsiVXZr9FNmKMeZi/lUcg7ZO22UbBihqW9a9D6VSHOo+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -496,7 +495,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.7.tgz",
       "integrity": "sha512-4J0Nl5gGmr5SKgR3FHK4J6rdG0aP5zAsY3AJU8YXH+D98CeNTjQUD8XHsdD2cTwo08V5mDdFa5VCsREpMPJ5gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -510,7 +508,6 @@
       "integrity": "sha512-r76vKBM7Wu0N8PTeec7340Gtv1wC7IBQGJOQnukshPgzaabgNKxmUiChGxi+RJNo/Tsdiw9ZfddcBgBjq79ZIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -543,7 +540,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.7.tgz",
       "integrity": "sha512-4bnskeRNNOZMn3buVw47Zz9Py4B8AZgYHe5xBEMOY5/yrldb7OFje5gWCWls23P18FKwhl+Xx1hgnOEPSs29gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -588,7 +584,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.7.tgz",
       "integrity": "sha512-nklVhstRZL4wpYg9Cyae/Eyfa7LMpgb0TyD/F//qCuohhM8nM7F+O0ekykGD6H+I34jsvqx6yLS7MicndWVz7Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -655,7 +650,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -928,6 +922,31 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -935,6 +954,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1648,7 +1668,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -3803,7 +3822,6 @@
       "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -4132,7 +4150,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4331,7 +4348,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -5179,7 +5195,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5621,7 +5636,6 @@
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6111,8 +6125,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.1.0.tgz",
       "integrity": "sha512-p/tjBw58O6vxKIWMlrU+yys8lqR3+l3UrqwNTT7wpj+dQ7N4etQekFM8joI+cWzPDYqZf54kN+hLC1+s5TvZvg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -6214,7 +6227,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -6682,7 +6694,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -7824,7 +7835,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8184,7 +8194,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8931,8 +8940,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -8970,7 +8978,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9110,7 +9117,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9420,7 +9426,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9439,8 +9444,7 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz",
       "integrity": "sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/angular-sandbox/src/app/app.html
+++ b/angular-sandbox/src/app/app.html
@@ -28,6 +28,22 @@
     </section>
 
     <section>
+      <h2>Combined width + height (both)</h2>
+      <div
+        class="demo-box both-demo"
+        [appCq]="bothBreakpoints"
+        [cqComparisonStrategy]="'both'"
+        [cqClassPrefix]="'both'"
+        #cqBoth="cq"
+      >
+        Resize width and height.
+      </div>
+      <p>Active combined breakpoint: {{ cqBoth.breakpoint() ?? 'none' }}</p>
+      <p>Dimensions: {{ cqBoth.dimensions().width }} x {{ cqBoth.dimensions().height }}</p>
+      <button type="button" (click)="logFromComponent(cqBoth, 'both')">Log combined-size logic</button>
+    </section>
+
+    <section>
       <h2>Using observable</h2>
       <div
         class="demo-box"

--- a/angular-sandbox/src/app/app.html
+++ b/angular-sandbox/src/app/app.html
@@ -57,23 +57,6 @@
     </section>
 
     <section>
-      <h2>Using CSS variables</h2>
-      <div
-        #cssVarBox
-        class="demo-box css-var-demo"
-        [appCq]="basicBreakpoints"
-        [cqCssVariables]="true"
-        [cqCssVarPrefix]="'demo-cq'"
-        #cqVars="cq"
-      >
-        CSS vars active: {{ cqVars.breakpoint() ?? 'none' }}
-      </div>
-      <p>--demo-cq-width: {{ cssVarValue(cssVarBox, '--demo-cq-width') || 'unset' }}</p>
-      <p>--demo-cq-height: {{ cssVarValue(cssVarBox, '--demo-cq-height') || 'unset' }}</p>
-      <p>--demo-cq-breakpoint: {{ cssVarValue(cssVarBox, '--demo-cq-breakpoint') || 'unset' }}</p>
-    </section>
-
-    <section>
       <h2>Observe parent container</h2>
       <div class="resize-parent demo-parent">
         <div class="demo-box inner-target" [appCq]="basicBreakpoints" [cqObserveParent]="true" #cqParent="cq">

--- a/angular-sandbox/src/app/app.html
+++ b/angular-sandbox/src/app/app.html
@@ -1,6 +1,99 @@
 <main class="main">
-  <div class="container">
+  <div class="container examples">
     <h1>Welcome to My Angular App</h1>
+
+    <section>
+      <h2>Basic usage</h2>
+      <div class="demo-box" [appCq]="basicBreakpoints" #cqBasic="cq">
+        Resize me using devtools.
+      </div>
+      <p>Active breakpoint: {{ cqBasic.breakpoint() ?? 'none' }}</p>
+      <p>Dimensions: {{ cqBasic.dimensions().width }} x {{ cqBasic.dimensions().height }}</p>
+      <button type="button" (click)="logFromComponent(cqBasic, 'basic')">Log size from component</button>
+    </section>
+
+    <section>
+      <h2>Multiple breakpoints (array input)</h2>
+      <div class="demo-box" [appCq]="cardBreakpoints" [cqClassPrefix]="'card'" #cqCards="cq">
+        Card mode: {{ cqCards.breakpoint() ?? 'none' }}
+      </div>
+    </section>
+
+    <section>
+      <h2>Using signals</h2>
+      <div class="demo-box" [appCq]="sizeBreakpoints" [cqComparisonStrategy]="'height'" #cqSignal="cq">
+        Signal breakpoint: {{ cqSignal.breakpoint() ?? 'none' }}
+      </div>
+      <button type="button" (click)="cqSignal.recalculate()">Manual recalculation</button>
+    </section>
+
+    <section>
+      <h2>Using observable</h2>
+      <div
+        class="demo-box"
+        [appCq]="basicBreakpoints"
+        [cqEmitOnBreakpointChangeOnly]="true"
+        #cqObservable="cq"
+      >
+        Observable stream demo
+      </div>
+      <p>Latest observable breakpoint: {{ (cqObservable.state$ | async)?.breakpoint ?? 'none' }}</p>
+    </section>
+
+    <section>
+      <h2>Using CSS variables</h2>
+      <div
+        #cssVarBox
+        class="demo-box css-var-demo"
+        [appCq]="basicBreakpoints"
+        [cqCssVariables]="true"
+        [cqCssVarPrefix]="'demo-cq'"
+        #cqVars="cq"
+      >
+        CSS vars active: {{ cqVars.breakpoint() ?? 'none' }}
+      </div>
+      <p>--demo-cq-width: {{ cssVarValue(cssVarBox, '--demo-cq-width') || 'unset' }}</p>
+      <p>--demo-cq-height: {{ cssVarValue(cssVarBox, '--demo-cq-height') || 'unset' }}</p>
+      <p>--demo-cq-breakpoint: {{ cssVarValue(cssVarBox, '--demo-cq-breakpoint') || 'unset' }}</p>
+    </section>
+
+    <section>
+      <h2>Observe parent container</h2>
+      <div class="resize-parent demo-parent">
+        <div class="demo-box inner-target" [appCq]="basicBreakpoints" [cqObserveParent]="true" #cqParent="cq">
+          This target reacts to parent size.
+        </div>
+      </div>
+      <p>Parent-driven breakpoint: {{ cqParent.breakpoint() ?? 'none' }}</p>
+      <button type="button" (click)="logFromComponent(cqParent, 'parent')">Log parent-observed size</button>
+    </section>
+
+    <section>
+      <h2>Observe another element (custom target)</h2>
+      <div class="demo-box trigger-source" #externalTrigger>
+        Resize this source box
+      </div>
+      <div
+        class="demo-box target-receiver"
+        [appCq]="basicBreakpoints"
+        [cqObserveTarget]="externalTrigger"
+        [cqClassPrefix]="'source'"
+        #cqExternal="cq"
+      >
+        This target reacts to the source box above.
+      </div>
+      <p>Source-driven breakpoint: {{ cqExternal.breakpoint() ?? 'none' }}</p>
+      <button type="button" (click)="logFromComponent(cqExternal, 'external-target')">
+        Log custom-target size
+      </button>
+    </section>
+
+    <section>
+      <h2>Class prefix customization</h2>
+      <div class="demo-box" [appCq]="basicBreakpoints" [cqClassPrefix]="'layout'" #cqPrefix="cq">
+        Custom class prefix applied. Active: {{ cqPrefix.state().activeClass ?? 'none' }}
+      </div>
+    </section>
   </div>
 
 </main>

--- a/angular-sandbox/src/app/app.scss
+++ b/angular-sandbox/src/app/app.scss
@@ -26,14 +26,6 @@ section {
     margin-bottom: 0.6rem;
 }
 
-.css-var-demo {
-    background: linear-gradient(120deg, #f4f7ff, #fff6e6);
-    border-color: #2f5bba;
-    box-shadow: inset 0 0 0 9999px rgba(47, 91, 186, 0.05);
-    border-width: clamp(2px, calc(var(--demo-cq-width, 320px) / 80), 12px);
-    min-height: clamp(120px, calc(var(--demo-cq-height, 180px) / 2), 260px);
-}
-
 .demo-parent {
     resize: horizontal;
     overflow: auto;

--- a/angular-sandbox/src/app/app.scss
+++ b/angular-sandbox/src/app/app.scss
@@ -70,6 +70,30 @@ section {
     border-color: #3ea35a;
 }
 
+.both-demo.both-small-short {
+    background: #ffe8f0;
+    color: #8e1b47;
+    border-color: #cf4f83;
+}
+
+.both-demo.both-small-tall {
+    background: #efe8ff;
+    color: #51329d;
+    border-color: #7b62d6;
+}
+
+.both-demo.both-wide-short {
+    background: #fff3e0;
+    color: #8a4b00;
+    border-color: #d58b2e;
+}
+
+.both-demo.both-wide-tall {
+    background: #e6f7ef;
+    color: #1d6d4e;
+    border-color: #3fb386;
+}
+
 .trigger-source {
     width: 420px;
     resize: horizontal;

--- a/angular-sandbox/src/app/app.scss
+++ b/angular-sandbox/src/app/app.scss
@@ -1,0 +1,109 @@
+.examples {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2rem;
+    display: grid;
+    gap: 1rem;
+}
+
+section {
+    border: 1px solid #d8d8d8;
+    border-radius: 12px;
+    padding: 1rem;
+    background: #fafafa;
+}
+
+.demo-box {
+    resize: both;
+    overflow: auto;
+    min-width: 220px;
+    max-width: 100%;
+    width: 360px;
+    min-height: 120px;
+    border: 2px dashed #4c4c4c;
+    border-radius: 10px;
+    padding: 0.8rem;
+    margin-bottom: 0.6rem;
+}
+
+.css-var-demo {
+    background: linear-gradient(120deg, #f4f7ff, #fff6e6);
+    border-color: #2f5bba;
+    box-shadow: inset 0 0 0 9999px rgba(47, 91, 186, 0.05);
+    border-width: clamp(2px, calc(var(--demo-cq-width, 320px) / 80), 12px);
+    min-height: clamp(120px, calc(var(--demo-cq-height, 180px) / 2), 260px);
+}
+
+.demo-parent {
+    resize: horizontal;
+    overflow: auto;
+    width: 520px;
+    max-width: 100%;
+    min-width: 240px;
+    border: 1px solid #b8b8b8;
+    border-radius: 10px;
+    padding: 0.75rem;
+    background: #ffffff;
+}
+
+.inner-target {
+    width: auto;
+    min-height: 90px;
+    resize: none;
+}
+
+.inner-target.cq-compact {
+    background: #ffe8e8;
+    color: #8f1f1f;
+    border-color: #d44343;
+}
+
+.inner-target.cq-regular {
+    background: #fff6de;
+    color: #8a5a00;
+    border-color: #d8a034;
+}
+
+.inner-target.cq-wide {
+    background: #e7f8ea;
+    color: #1e6c2f;
+    border-color: #3ea35a;
+}
+
+.trigger-source {
+    width: 420px;
+    resize: horizontal;
+    border-color: #1f7a4c;
+    background: #effaf4;
+}
+
+.target-receiver {
+    border-color: #a85c14;
+    background: #fff5ea;
+}
+
+.target-receiver.source-compact {
+    background: #ffe9ef;
+    color: #9b2048;
+    border-color: #d2457a;
+}
+
+.target-receiver.source-regular {
+    background: #eef2ff;
+    color: #2f44a0;
+    border-color: #4a6ed8;
+}
+
+.target-receiver.source-wide {
+    background: #e8fbf4;
+    color: #1f7a5d;
+    border-color: #2fba87;
+}
+
+button {
+    border: 0;
+    border-radius: 8px;
+    padding: 0.45rem 0.75rem;
+    background: #264653;
+    color: #fff;
+}

--- a/angular-sandbox/src/app/app.ts
+++ b/angular-sandbox/src/app/app.ts
@@ -65,8 +65,4 @@ export class App {
       state: cq.state(),
     });
   }
-
-  protected cssVarValue(element: HTMLElement, varName: string): string {
-    return getComputedStyle(element).getPropertyValue(varName).trim();
-  }
 }

--- a/angular-sandbox/src/app/app.ts
+++ b/angular-sandbox/src/app/app.ts
@@ -1,14 +1,65 @@
-import { Component } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, effect, viewChild } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { type CqBreakpointsInput, ContainerQueryDirective } from './directives/container-query.directive';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, AsyncPipe, ContainerQueryDirective],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
 export class App {
   protected title = 'angular-sandbox';
 
- 
+  private readonly cqBasic = viewChild<ContainerQueryDirective>('cqBasic');
+
+  protected readonly basicBreakpoints: CqBreakpointsInput = {
+    compact: { maxWidth: 479 },
+    regular: { minWidth: 480, maxWidth: 839 },
+    wide: { minWidth: 840 },
+  };
+
+  protected readonly cardBreakpoints: CqBreakpointsInput = [
+    { name: 'xs', maxWidth: 299 },
+    { name: 'sm', minWidth: 300, maxWidth: 499 },
+    { name: 'md', minWidth: 500, maxWidth: 799 },
+    { name: 'lg', minWidth: 800 },
+  ];
+
+  protected readonly sizeBreakpoints: CqBreakpointsInput = {
+    short: { maxHeight: 239 },
+    tall: { minHeight: 240 },
+  };
+
+  constructor() {
+    effect((onCleanup) => {
+      const cq = this.cqBasic();
+      if (!cq) {
+        return;
+      }
+
+      const subscription = cq.state$.subscribe((state) => {
+          console.log('[cqBasic state$]', state);
+        });
+
+      onCleanup(() => {
+        subscription.unsubscribe();
+      });
+    });
+  }
+
+  protected logFromComponent(cq: ContainerQueryDirective, label: string): void {
+    const size = cq.dimensions();
+    console.log(`[${label}]`, {
+      breakpoint: cq.breakpoint(),
+      width: size.width,
+      height: size.height,
+      state: cq.state(),
+    });
+  }
+
+  protected cssVarValue(element: HTMLElement, varName: string): string {
+    return getComputedStyle(element).getPropertyValue(varName).trim();
+  }
 }

--- a/angular-sandbox/src/app/app.ts
+++ b/angular-sandbox/src/app/app.ts
@@ -32,6 +32,13 @@ export class App {
     tall: { minHeight: 240 },
   };
 
+  protected readonly bothBreakpoints: CqBreakpointsInput = {
+    'small-short': { maxWidth: 459, maxHeight: 229 },
+    'small-tall': { maxWidth: 459, minHeight: 230 },
+    'wide-short': { minWidth: 460, maxHeight: 229 },
+    'wide-tall': { minWidth: 460, minHeight: 230 },
+  };
+
   constructor() {
     effect((onCleanup) => {
       const cq = this.cqBasic();

--- a/angular-sandbox/src/app/directives/container-query.directive.spec.ts
+++ b/angular-sandbox/src/app/directives/container-query.directive.spec.ts
@@ -1,0 +1,263 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ContainerQueryDirective, type CqBreakpointsInput } from './container-query.directive';
+
+class MockResizeObserver implements ResizeObserver {
+  static latest: MockResizeObserver | null = null;
+
+  readonly observed = new Set<Element>();
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    MockResizeObserver.latest = this;
+  }
+
+  observe(target: Element): void {
+    this.observed.add(target);
+  }
+
+  unobserve(target: Element): void {
+    this.observed.delete(target);
+  }
+
+  disconnect(): void {
+    this.observed.clear();
+  }
+
+  takeRecords(): ResizeObserverEntry[] {
+    return [];
+  }
+
+  emit(): void {
+    const entries = Array.from(this.observed).map((target) => ({
+      target,
+      contentRect: target.getBoundingClientRect(),
+    })) as ResizeObserverEntry[];
+
+    this.callback(entries, this);
+  }
+}
+
+@Component({
+  standalone: true,
+  imports: [ContainerQueryDirective],
+  template: `
+    <div
+      class="host"
+      [appCq]="breakpoints"
+      [cqComparisonStrategy]="strategy"
+      [cqClassPrefix]="classPrefix"
+      [cqCssVariables]="cssVars"
+      [cqCssVarPrefix]="cssVarPrefix"
+      [cqDefaultBreakpoint]="defaultBreakpoint"
+      [cqEmitOnBreakpointChangeOnly]="emitOnChangeOnly"
+      #cq="cq"
+    ></div>
+
+    <div class="parent" [style.width.px]="parentWidth" [style.height.px]="parentHeight">
+      <div class="child" [appCq]="breakpoints" [cqObserveParent]="true" #parentCq="cq"></div>
+    </div>
+
+    <div class="external-source" #externalSource [style.width.px]="externalWidth" [style.height.px]="externalHeight"></div>
+    <div class="external-target" [appCq]="breakpoints" [cqObserveTarget]="externalSource" #externalCq="cq"></div>
+  `,
+})
+class HostComponent {
+  breakpoints: CqBreakpointsInput = {
+    small: { maxWidth: 399 },
+    medium: { minWidth: 400, maxWidth: 799 },
+    large: { minWidth: 800 },
+  };
+
+  strategy: 'width' | 'height' | 'both' = 'width';
+  classPrefix = 'cq';
+  cssVars = false;
+  cssVarPrefix = 'cq';
+  defaultBreakpoint: string | null = null;
+  emitOnChangeOnly = false;
+
+  parentWidth = 550;
+  parentHeight = 320;
+  externalWidth = 820;
+  externalHeight = 300;
+
+  @ViewChild('cq', { static: true })
+  cqDirective!: ContainerQueryDirective;
+
+  @ViewChild('parentCq', { static: true })
+  parentDirective!: ContainerQueryDirective;
+
+  @ViewChild('externalCq', { static: true })
+  externalDirective!: ContainerQueryDirective;
+}
+
+describe('ContainerQueryDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let hostComponent: HostComponent;
+  let hostEl: HTMLElement;
+  let parentEl: HTMLElement;
+  let externalSourceEl: HTMLElement;
+  let originalResizeObserver: typeof ResizeObserver | undefined;
+
+  beforeEach(async () => {
+    originalResizeObserver = (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+    (globalThis as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      MockResizeObserver as unknown as typeof ResizeObserver;
+
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    hostComponent = fixture.componentInstance;
+    fixture.detectChanges();
+
+    hostEl = fixture.nativeElement.querySelector('.host') as HTMLElement;
+    parentEl = fixture.nativeElement.querySelector('.parent') as HTMLElement;
+    externalSourceEl = fixture.nativeElement.querySelector('.external-source') as HTMLElement;
+  });
+
+  afterEach(() => {
+    if (originalResizeObserver) {
+      (globalThis as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = originalResizeObserver;
+    } else {
+      delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+    }
+  });
+
+  it('should create', () => {
+    expect(hostComponent.cqDirective).toBeTruthy();
+  });
+
+  it('should apply only the active class for matched breakpoint', () => {
+    setRect(hostEl, 320, 200);
+    hostComponent.cqDirective.recalculate();
+    fixture.detectChanges();
+
+    expect(hostEl.classList.contains('cq-small')).toBeTrue();
+    expect(hostEl.classList.contains('cq-medium')).toBeFalse();
+
+    setRect(hostEl, 640, 200);
+    hostComponent.cqDirective.recalculate();
+    fixture.detectChanges();
+
+    expect(hostEl.classList.contains('cq-small')).toBeFalse();
+    expect(hostEl.classList.contains('cq-medium')).toBeTrue();
+  });
+
+  it('should support breakpoint array input', () => {
+    hostComponent.breakpoints = [
+      { name: 'tiny', maxWidth: 199 },
+      { name: 'wide', minWidth: 200 },
+    ];
+
+    setRect(hostEl, 500, 200);
+    fixture.detectChanges();
+    hostComponent.cqDirective.recalculate();
+
+    expect(hostComponent.cqDirective.breakpoint()).toBe('wide');
+  });
+
+  it('should support height-only strategy', () => {
+    hostComponent.strategy = 'height';
+    hostComponent.breakpoints = {
+      short: { maxHeight: 299 },
+      tall: { minHeight: 300 },
+    };
+
+    setRect(hostEl, 100, 360);
+    fixture.detectChanges();
+    hostComponent.cqDirective.recalculate();
+
+    expect(hostComponent.cqDirective.breakpoint()).toBe('tall');
+  });
+
+  it('should use default breakpoint when no match exists', () => {
+    hostComponent.breakpoints = {
+      huge: { minWidth: 900 },
+    };
+    hostComponent.defaultBreakpoint = 'huge';
+
+    setRect(hostEl, 300, 200);
+    fixture.detectChanges();
+    hostComponent.cqDirective.recalculate();
+
+    expect(hostComponent.cqDirective.breakpoint()).toBe('huge');
+  });
+
+  it('should write css variables when enabled', () => {
+    hostComponent.cssVars = true;
+    hostComponent.cssVarPrefix = 'demo';
+
+    setRect(hostEl, 640, 360);
+    fixture.detectChanges();
+    hostComponent.cqDirective.recalculate();
+
+    expect(hostEl.style.getPropertyValue('--demo-width')).toBe('640px');
+    expect(hostEl.style.getPropertyValue('--demo-height')).toBe('360px');
+    expect(hostEl.style.getPropertyValue('--demo-size')).toBe('640x360');
+    expect(hostEl.style.getPropertyValue('--demo-breakpoint')).toBe('medium');
+  });
+
+  it('should support observing parent container size', () => {
+    setRect(parentEl, 760, 320);
+    hostComponent.parentDirective.recalculate();
+
+    expect(hostComponent.parentDirective.breakpoint()).toBe('medium');
+  });
+
+  it('should support observing a custom target element', () => {
+    setRect(externalSourceEl, 910, 280);
+    hostComponent.externalDirective.recalculate();
+
+    expect(hostComponent.externalDirective.breakpoint()).toBe('large');
+    expect(hostComponent.externalDirective.dimensions()).toEqual({ width: 910, height: 280 });
+  });
+
+  it('should emit observable updates only on breakpoint changes when configured', () => {
+    hostComponent.emitOnChangeOnly = true;
+
+    setRect(hostEl, 350, 200);
+    fixture.detectChanges();
+
+    const emitted: Array<string | null> = [];
+    const subscription = hostComponent.cqDirective.state$.subscribe((state) => {
+      emitted.push(state.breakpoint);
+    });
+
+    hostComponent.cqDirective.recalculate();
+    setRect(hostEl, 360, 210);
+    hostComponent.cqDirective.recalculate();
+    setRect(hostEl, 900, 210);
+    hostComponent.cqDirective.recalculate();
+
+    subscription.unsubscribe();
+
+    expect(emitted).toEqual(['small', 'large']);
+  });
+
+  it('should allow manual recalculation', () => {
+    setRect(hostEl, 900, 100);
+
+    hostComponent.cqDirective.recalculate();
+
+    expect(hostComponent.cqDirective.breakpoint()).toBe('large');
+    expect(hostComponent.cqDirective.dimensions()).toEqual({ width: 900, height: 100 });
+  });
+
+  function setRect(element: HTMLElement, width: number, height: number): void {
+    const rect = {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      bottom: height,
+      right: width,
+      width,
+      height,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    (element as HTMLElement & { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = () =>
+      rect;
+  }
+});

--- a/angular-sandbox/src/app/directives/container-query.directive.spec.ts
+++ b/angular-sandbox/src/app/directives/container-query.directive.spec.ts
@@ -46,8 +46,6 @@ class MockResizeObserver implements ResizeObserver {
       [appCq]="breakpoints"
       [cqComparisonStrategy]="strategy"
       [cqClassPrefix]="classPrefix"
-      [cqCssVariables]="cssVars"
-      [cqCssVarPrefix]="cssVarPrefix"
       [cqDefaultBreakpoint]="defaultBreakpoint"
       [cqEmitOnBreakpointChangeOnly]="emitOnChangeOnly"
       #cq="cq"
@@ -70,8 +68,6 @@ class HostComponent {
 
   strategy: 'width' | 'height' | 'both' = 'width';
   classPrefix = 'cq';
-  cssVars = false;
-  cssVarPrefix = 'cq';
   defaultBreakpoint: string | null = null;
   emitOnChangeOnly = false;
 
@@ -182,20 +178,6 @@ describe('ContainerQueryDirective', () => {
     hostComponent.cqDirective.recalculate();
 
     expect(hostComponent.cqDirective.breakpoint()).toBe('huge');
-  });
-
-  it('should write css variables when enabled', () => {
-    hostComponent.cssVars = true;
-    hostComponent.cssVarPrefix = 'demo';
-
-    setRect(hostEl, 640, 360);
-    fixture.detectChanges();
-    hostComponent.cqDirective.recalculate();
-
-    expect(hostEl.style.getPropertyValue('--demo-width')).toBe('640px');
-    expect(hostEl.style.getPropertyValue('--demo-height')).toBe('360px');
-    expect(hostEl.style.getPropertyValue('--demo-size')).toBe('640x360');
-    expect(hostEl.style.getPropertyValue('--demo-breakpoint')).toBe('medium');
   });
 
   it('should support observing parent container size', () => {

--- a/angular-sandbox/src/app/directives/container-query.directive.ts
+++ b/angular-sandbox/src/app/directives/container-query.directive.ts
@@ -4,7 +4,6 @@ import {
     ElementRef,
     NgZone,
     Renderer2,
-    RendererStyleFlags2,
     computed,
     effect,
     inject,
@@ -61,11 +60,9 @@ export class ContainerQueryDirective {
   readonly observeParent = input<boolean>(false, { alias: 'cqObserveParent' });
   readonly observeTarget = input<CqObserveTargetInput>(null, { alias: 'cqObserveTarget' });
   readonly classPrefix = input<string>('cq', { alias: 'cqClassPrefix' });
-  readonly cssVarPrefix = input<string>('cq', { alias: 'cqCssVarPrefix' });
   readonly comparisonStrategy = input<CqComparisonStrategy>('width', {
     alias: 'cqComparisonStrategy',
   });
-  readonly writeCssVariables = input<boolean>(false, { alias: 'cqCssVariables' });
 
   private readonly hostElementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly renderer = inject(Renderer2);
@@ -100,9 +97,7 @@ export class ContainerQueryDirective {
         this.observeParent();
         this.observeTarget();
         this.classPrefix();
-        this.cssVarPrefix();
         this.comparisonStrategy();
-        this.writeCssVariables();
 
         this.connectObserver();
         this.recalculate();
@@ -138,7 +133,6 @@ export class ContainerQueryDirective {
     const nextClass = active ? `${classPrefix}-${toKebab(active.name)}` : null;
 
     this.updateHostClass(nextClass);
-    this.updateCssVariables(dimensions, active?.name ?? null);
 
     const nextState: CqState = {
       breakpoint: active?.name ?? null,
@@ -244,44 +238,6 @@ export class ContainerQueryDirective {
 
     this.renderer.removeClass(this.hostElementRef.nativeElement, this.appliedClass);
     this.appliedClass = null;
-  }
-
-  private updateCssVariables(dimensions: CqDimensions, breakpoint: string | null): void {
-    const host = this.hostElementRef.nativeElement;
-    const prefix = sanitizeToken(this.cssVarPrefix(), 'cq');
-
-    if (!this.writeCssVariables()) {
-      this.renderer.removeStyle(host, `--${prefix}-width`, RendererStyleFlags2.DashCase);
-      this.renderer.removeStyle(host, `--${prefix}-height`, RendererStyleFlags2.DashCase);
-      this.renderer.removeStyle(host, `--${prefix}-size`, RendererStyleFlags2.DashCase);
-      this.renderer.removeStyle(host, `--${prefix}-breakpoint`, RendererStyleFlags2.DashCase);
-      return;
-    }
-
-    this.renderer.setStyle(
-      host,
-      `--${prefix}-width`,
-      `${dimensions.width}px`,
-      RendererStyleFlags2.DashCase,
-    );
-    this.renderer.setStyle(
-      host,
-      `--${prefix}-height`,
-      `${dimensions.height}px`,
-      RendererStyleFlags2.DashCase,
-    );
-    this.renderer.setStyle(
-      host,
-      `--${prefix}-size`,
-      `${dimensions.width}x${dimensions.height}`,
-      RendererStyleFlags2.DashCase,
-    );
-    this.renderer.setStyle(
-      host,
-      `--${prefix}-breakpoint`,
-      breakpoint ?? 'none',
-      RendererStyleFlags2.DashCase,
-    );
   }
 }
 

--- a/angular-sandbox/src/app/directives/container-query.directive.ts
+++ b/angular-sandbox/src/app/directives/container-query.directive.ts
@@ -1,0 +1,442 @@
+import {
+    DestroyRef,
+    Directive,
+    ElementRef,
+    NgZone,
+    Renderer2,
+    RendererStyleFlags2,
+    computed,
+    effect,
+    inject,
+    input,
+    signal,
+} from '@angular/core';
+import { Observable, ReplaySubject } from 'rxjs';
+
+export type CqComparisonStrategy = 'width' | 'height' | 'both';
+
+export interface CqBreakpointRange {
+  minWidth?: number;
+  maxWidth?: number;
+  minHeight?: number;
+  maxHeight?: number;
+}
+
+export interface CqNamedBreakpoint extends CqBreakpointRange {
+  name: string;
+}
+
+export type CqBreakpointMap = Record<string, CqBreakpointRange>;
+
+export type CqBreakpointsInput = ReadonlyArray<CqNamedBreakpoint> | CqBreakpointMap;
+export type CqObserveTargetInput = HTMLElement | string | null;
+
+export interface CqDimensions {
+  width: number;
+  height: number;
+}
+
+export interface CqState {
+  breakpoint: string | null;
+  dimensions: CqDimensions;
+  matchedBreakpoints: readonly string[];
+  activeClass: string | null;
+}
+
+interface NormalizedBreakpoint extends CqNamedBreakpoint {
+  index: number;
+}
+
+@Directive({
+  selector: '[appCq]',
+  standalone: true,
+  exportAs: 'cq',
+})
+export class ContainerQueryDirective {
+  readonly breakpointsInput = input.required<CqBreakpointsInput>({ alias: 'appCq' });
+  readonly defaultBreakpoint = input<string | null>(null, { alias: 'cqDefaultBreakpoint' });
+  readonly emitOnBreakpointChangeOnly = input<boolean>(false, {
+    alias: 'cqEmitOnBreakpointChangeOnly',
+  });
+  readonly observeParent = input<boolean>(false, { alias: 'cqObserveParent' });
+  readonly observeTarget = input<CqObserveTargetInput>(null, { alias: 'cqObserveTarget' });
+  readonly classPrefix = input<string>('cq', { alias: 'cqClassPrefix' });
+  readonly cssVarPrefix = input<string>('cq', { alias: 'cqCssVarPrefix' });
+  readonly comparisonStrategy = input<CqComparisonStrategy>('width', {
+    alias: 'cqComparisonStrategy',
+  });
+  readonly writeCssVariables = input<boolean>(false, { alias: 'cqCssVariables' });
+
+  private readonly hostElementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly renderer = inject(Renderer2);
+  private readonly zone = inject(NgZone);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private resizeObserver: ResizeObserver | null = null;
+  private observedElement: HTMLElement | null = null;
+  private appliedClass: string | null = null;
+  private lastEmittedBreakpoint: string | null = null;
+
+  private readonly liveStateSignal = signal<CqState>({
+    breakpoint: null,
+    dimensions: { width: 0, height: 0 },
+    matchedBreakpoints: [],
+    activeClass: null,
+  });
+
+  private readonly changesSubject = new ReplaySubject<CqState>(1);
+
+  readonly state = this.liveStateSignal.asReadonly();
+  readonly state$: Observable<CqState> = this.changesSubject.asObservable();
+  readonly breakpoint = computed(() => this.liveStateSignal().breakpoint);
+  readonly dimensions = computed(() => this.liveStateSignal().dimensions);
+
+  constructor() {
+    this.zone.runOutsideAngular(() => {
+      effect(() => {
+        this.breakpointsInput();
+        this.defaultBreakpoint();
+        this.emitOnBreakpointChangeOnly();
+        this.observeParent();
+        this.observeTarget();
+        this.classPrefix();
+        this.cssVarPrefix();
+        this.comparisonStrategy();
+        this.writeCssVariables();
+
+        this.connectObserver();
+        this.recalculate();
+      });
+    });
+
+    this.destroyRef.onDestroy(() => {
+      this.disconnectObserver();
+      this.clearAppliedClass();
+      this.changesSubject.complete();
+    });
+  }
+
+  recalculate(): void {
+    const target = this.resolveObservedElement();
+    if (!target) {
+      return;
+    }
+
+    const dimensions = readDimensions(target);
+    const normalizedBreakpoints = normalizeBreakpoints(this.breakpointsInput());
+    const strategy = this.comparisonStrategy();
+    const matches = normalizedBreakpoints.filter((bp) => isBreakpointMatch(bp, dimensions, strategy));
+
+    const active = selectActiveBreakpoint(
+      matches,
+      normalizedBreakpoints,
+      this.defaultBreakpoint(),
+      strategy,
+    );
+
+    const classPrefix = sanitizeToken(this.classPrefix(), 'cq');
+    const nextClass = active ? `${classPrefix}-${toKebab(active.name)}` : null;
+
+    this.updateHostClass(nextClass);
+    this.updateCssVariables(dimensions, active?.name ?? null);
+
+    const nextState: CqState = {
+      breakpoint: active?.name ?? null,
+      dimensions,
+      matchedBreakpoints: matches.map((bp) => bp.name),
+      activeClass: nextClass,
+    };
+
+    this.liveStateSignal.set(nextState);
+
+    if (
+      !this.emitOnBreakpointChangeOnly() ||
+      this.lastEmittedBreakpoint !== nextState.breakpoint
+    ) {
+      this.changesSubject.next(nextState);
+      this.lastEmittedBreakpoint = nextState.breakpoint;
+    }
+  }
+
+  private connectObserver(): void {
+    const target = this.resolveObservedElement();
+    if (!target) {
+      this.disconnectObserver();
+      return;
+    }
+
+    if (this.observedElement === target && this.resizeObserver) {
+      return;
+    }
+
+    this.disconnectObserver();
+
+    if (!('ResizeObserver' in globalThis)) {
+      return;
+    }
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.recalculate();
+    });
+
+    this.resizeObserver.observe(target);
+    this.observedElement = target;
+  }
+
+  private disconnectObserver(): void {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+    this.observedElement = null;
+  }
+
+  private resolveObservedElement(): HTMLElement | null {
+    const host = this.hostElementRef.nativeElement;
+
+    const customTarget = this.resolveCustomTarget(host);
+    if (customTarget) {
+      return customTarget;
+    }
+
+    if (!this.observeParent()) {
+      return host;
+    }
+
+    return host.parentElement ?? host;
+  }
+
+  private resolveCustomTarget(host: HTMLElement): HTMLElement | null {
+    const target = this.observeTarget();
+    if (!target) {
+      return null;
+    }
+
+    if (target instanceof HTMLElement) {
+      return target;
+    }
+
+    const root = host.getRootNode();
+    if (root instanceof ShadowRoot || root instanceof Document) {
+      return root.querySelector<HTMLElement>(target);
+    }
+
+    return null;
+  }
+
+  private updateHostClass(nextClass: string | null): void {
+    if (this.appliedClass === nextClass) {
+      return;
+    }
+
+    this.clearAppliedClass();
+
+    if (nextClass) {
+      this.renderer.addClass(this.hostElementRef.nativeElement, nextClass);
+      this.appliedClass = nextClass;
+    }
+  }
+
+  private clearAppliedClass(): void {
+    if (!this.appliedClass) {
+      return;
+    }
+
+    this.renderer.removeClass(this.hostElementRef.nativeElement, this.appliedClass);
+    this.appliedClass = null;
+  }
+
+  private updateCssVariables(dimensions: CqDimensions, breakpoint: string | null): void {
+    const host = this.hostElementRef.nativeElement;
+    const prefix = sanitizeToken(this.cssVarPrefix(), 'cq');
+
+    if (!this.writeCssVariables()) {
+      this.renderer.removeStyle(host, `--${prefix}-width`, RendererStyleFlags2.DashCase);
+      this.renderer.removeStyle(host, `--${prefix}-height`, RendererStyleFlags2.DashCase);
+      this.renderer.removeStyle(host, `--${prefix}-size`, RendererStyleFlags2.DashCase);
+      this.renderer.removeStyle(host, `--${prefix}-breakpoint`, RendererStyleFlags2.DashCase);
+      return;
+    }
+
+    this.renderer.setStyle(
+      host,
+      `--${prefix}-width`,
+      `${dimensions.width}px`,
+      RendererStyleFlags2.DashCase,
+    );
+    this.renderer.setStyle(
+      host,
+      `--${prefix}-height`,
+      `${dimensions.height}px`,
+      RendererStyleFlags2.DashCase,
+    );
+    this.renderer.setStyle(
+      host,
+      `--${prefix}-size`,
+      `${dimensions.width}x${dimensions.height}`,
+      RendererStyleFlags2.DashCase,
+    );
+    this.renderer.setStyle(
+      host,
+      `--${prefix}-breakpoint`,
+      breakpoint ?? 'none',
+      RendererStyleFlags2.DashCase,
+    );
+  }
+}
+
+function readDimensions(element: HTMLElement): CqDimensions {
+  const rect = element.getBoundingClientRect();
+  return {
+    width: Math.round(rect.width),
+    height: Math.round(rect.height),
+  };
+}
+
+function normalizeBreakpoints(inputBreakpoints: CqBreakpointsInput): NormalizedBreakpoint[] {
+  const list = Array.isArray(inputBreakpoints)
+    ? inputBreakpoints.map((bp, index) => ({ ...bp, index }))
+    : Object.entries(inputBreakpoints).map(([name, range], index) => ({
+        name,
+        ...range,
+        index,
+      }));
+
+  for (const bp of list) {
+    assertRange(bp.name, bp.minWidth, bp.maxWidth, 'width');
+    assertRange(bp.name, bp.minHeight, bp.maxHeight, 'height');
+  }
+
+  return list;
+}
+
+function assertRange(
+  name: string,
+  min: number | undefined,
+  max: number | undefined,
+  axis: 'width' | 'height',
+): void {
+  if (min !== undefined && max !== undefined && min > max) {
+    throw new Error(`Invalid ${axis} range for breakpoint "${name}": min cannot be greater than max.`);
+  }
+}
+
+function isBreakpointMatch(
+  breakpoint: CqBreakpointRange,
+  dimensions: CqDimensions,
+  strategy: CqComparisonStrategy,
+): boolean {
+  const widthMatch = isWithin(dimensions.width, breakpoint.minWidth, breakpoint.maxWidth);
+  const heightMatch = isWithin(dimensions.height, breakpoint.minHeight, breakpoint.maxHeight);
+
+  if (strategy === 'width') {
+    return widthMatch;
+  }
+
+  if (strategy === 'height') {
+    return heightMatch;
+  }
+
+  return widthMatch && heightMatch;
+}
+
+function isWithin(value: number, min?: number, max?: number): boolean {
+  if (min !== undefined && value < min) {
+    return false;
+  }
+  if (max !== undefined && value > max) {
+    return false;
+  }
+  return true;
+}
+
+function selectActiveBreakpoint(
+  matches: readonly NormalizedBreakpoint[],
+  all: readonly NormalizedBreakpoint[],
+  defaultName: string | null,
+  strategy: CqComparisonStrategy,
+): NormalizedBreakpoint | null {
+  if (matches.length > 0) {
+    return [...matches].sort((a, b) => compareSpecificity(a, b, strategy))[0] ?? null;
+  }
+
+  if (!defaultName) {
+    return null;
+  }
+
+  return all.find((bp) => bp.name === defaultName) ?? null;
+}
+
+function compareSpecificity(
+  a: NormalizedBreakpoint,
+  b: NormalizedBreakpoint,
+  strategy: CqComparisonStrategy,
+): number {
+  const aScore = specificityScore(a, strategy);
+  const bScore = specificityScore(b, strategy);
+
+  if (aScore.constrainedAxes !== bScore.constrainedAxes) {
+    return bScore.constrainedAxes - aScore.constrainedAxes;
+  }
+
+  if (aScore.totalSpan !== bScore.totalSpan) {
+    return aScore.totalSpan - bScore.totalSpan;
+  }
+
+  if (aScore.totalMin !== bScore.totalMin) {
+    return bScore.totalMin - aScore.totalMin;
+  }
+
+  return a.index - b.index;
+}
+
+function specificityScore(bp: NormalizedBreakpoint, strategy: CqComparisonStrategy) {
+  const includeWidth = strategy === 'width' || strategy === 'both';
+  const includeHeight = strategy === 'height' || strategy === 'both';
+
+  const width = includeWidth ? rangeSpan(bp.minWidth, bp.maxWidth) : null;
+  const height = includeHeight ? rangeSpan(bp.minHeight, bp.maxHeight) : null;
+
+  const constrainedAxes = [width, height].filter((axis) => axis && axis.constrained).length;
+  const totalSpan = [width, height]
+    .filter((axis): axis is NonNullable<typeof axis> => axis !== null)
+    .reduce((sum, axis) => sum + axis.span, 0);
+
+  const totalMin = [bp.minWidth, bp.minHeight]
+    .filter((value): value is number => value !== undefined)
+    .reduce((sum, value) => sum + value, 0);
+
+  return {
+    constrainedAxes,
+    totalSpan,
+    totalMin,
+  };
+}
+
+function rangeSpan(min?: number, max?: number): { span: number; constrained: boolean } {
+  if (min !== undefined && max !== undefined) {
+    return { span: max - min, constrained: true };
+  }
+
+  if (min !== undefined || max !== undefined) {
+    return { span: Number.POSITIVE_INFINITY, constrained: true };
+  }
+
+  return { span: Number.POSITIVE_INFINITY, constrained: false };
+}
+
+function sanitizeToken(value: string, fallback: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  return toKebab(trimmed);
+}
+
+function toKebab(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+}


### PR DESCRIPTION
- [x] Understand the feedback: remove CSS variables support, keep pixel-only input
- [x] Remove `writeCssVariables` and `cssVarPrefix` inputs from the directive
- [x] Remove `updateCssVariables` method and `RendererStyleFlags2` import from the directive
- [x] Remove CSS variables test from spec file
- [x] Remove CSS variables demo section from app.html
- [x] Remove `.css-var-demo` styles from app.scss
- [x] Remove `cssVarValue()` method from app.ts
- [x] Build and test confirm no regressions (11/11 tests pass)